### PR TITLE
optimize 验证码图片文件不直接写盘

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -77,6 +77,9 @@ class Result
      */
     function getImageFile()
     {
+        if(!file_exists($this->CaptchaFile)){
+            file_put_contents($this->CaptchaFile, $this->CaptchaByte);
+        }
         return $this->CaptchaFile;
     }
 }

--- a/src/VerifyCode.php
+++ b/src/VerifyCode.php
@@ -82,9 +82,12 @@ class VerifyCode
         mt_srand();
         $filePath = $this->temp . date('YmdHis') . rand(1000,9999) .'.'.MIME::getExtensionName($this->mime);
         $func = 'image' . MIME::getExtensionName($this->mime);
-        $func($this->imInstance, $filePath);
+        ob_start();
+        $func($this->imInstance);
+        $file = ob_get_contents();
+        ob_end_clean();
         imagedestroy($this->imInstance);
-        return new Result(file_get_contents($filePath), $Code, $this->mime, $filePath);
+        return new Result($file, $Code, $this->mime, $filePath);
     }
 
     /**


### PR DESCRIPTION
## 为什么改动
* 我们使用docker 部署导致 /tmp 有大量验证码图片文件存在 最高峰时有600万+
* 生成验证码时会有写入和读取的两次io操作
* 验证码再发送后无用， 不需要落盘

 > 向前兼容 在调用 Result::getImageFile 时会将图片写入 Result::CaptchaFile指定的目录